### PR TITLE
Initial jump speed should not use DeltaTime

### DIFF
--- a/Source/Game/DemoFps.cs
+++ b/Source/Game/DemoFps.cs
@@ -144,7 +144,7 @@ public class DemoFps : Script, IKinematicCharacter
 			if(_kcc.IsGrounded)
 			{
 				_kcc.ForceUnground();
-				_velocity.Y = 800 * Time.DeltaTime;
+				_velocity.Y = 14.0f;
 			}
 		}
 		


### PR DESCRIPTION
Jump height was dependant on framerate. 
I setted a value that feels nice for jumping on all the platforms in the demo scene.