### PR TITLE
Improved ceiling detection

### DIFF
--- a/Source/Game/DemoFps.cs
+++ b/Source/Game/DemoFps.cs
@@ -211,9 +211,22 @@ public class DemoFps : Script, IKinematicCharacter
 
     public void KinematicCollision(RayCastHit hit)
     {
-		//jumping against ceilings its bit awkward without reseting the Y velocity upon ceiling contact
-		if(Math.Round(Vector3.Dot(hit.Normal, _kcc.GravityEulerNormalized), 4, MidpointRounding.ToZero) > 0.0f &&
-			_velocity.Y > 0)
+		// Only treat as ceiling if:
+		// 1. The normal faces generally downward (dot with gravity > 0.7)
+		// 2. The collision point is above the character's center (relative to gravity)
+		// 3. The character is moving upward
+
+		// 1. Normal faces downward (ceiling)
+		float normalDotGravity = Vector3.Dot(hit.Normal, _kcc.GravityEulerNormalized);
+
+		// 2. Collision point is above character (relative to gravity)
+		Vector3 characterToHitDistance = hit.Point - _kcc.Position;
+		float hitAbove = Vector3.Dot(characterToHitDistance, -_kcc.GravityEulerNormalized);
+
+		// 3. Character is moving upward (against gravity)
+		float velocityAgainstGravity = Vector3.Dot(_velocity, -_kcc.GravityEulerNormalized);
+
+		if (normalDotGravity > 0.7f && hitAbove > 0 && velocityAgainstGravity > 0)
 		{
 			_velocity.Y = 0.0f;
 		}


### PR DESCRIPTION
Ceiling detection is failing on some cases. The Easiest way to reproduce is changing this code:

```
		if(Vector3.Dot(hit.Normal, _kcc.GravityEulerNormalized) > 0.0f &&
			_velocity.Y > 0)
		{
			_velocity.Y = 30.0f;   //We will jump even more if we "detect" a ceiling
		}
```

Go to this vertical wall, walk towards it and jump without releasing the W key.

<img width="1090" height="592" alt="imagen" src="https://github.com/user-attachments/assets/dfd34d3c-d99d-4073-8b2b-052c8daa99e1" />

The code detects a ceiling, and you will jump up to the sky.

<img width="1920" height="1080" alt="imagen" src="https://github.com/user-attachments/assets/fa875cd6-42e8-4897-bc0f-e0bf467f6b20" />


This PR fixes this problem, and allows the player to slide on ceilings with an almost vertical angle, wich feels more natural to me.

<img width="1080" height="568" alt="imagen" src="https://github.com/user-attachments/assets/3ee467a1-8213-49b2-8ede-414c966cbb1b" />
