### PR TITLE
Gravity should not use DeltaTime

### DIFF
--- a/Source/Game/DemoFps.cs
+++ b/Source/Game/DemoFps.cs
@@ -123,7 +123,7 @@ public class DemoFps : Script, IKinematicCharacter
 		if(!_kcc.IsGrounded)
 		{
 			//airmove
-			_velocity.Y -= 30 * Time.DeltaTime;
+			_velocity.Y -= 0.6f;
 			Q3Accelerate(input, 5, 2.0f);
 		}
 		else


### PR DESCRIPTION
This can easily be checked by showing the highest position reached when jumping.

```
		if(!_kcc.IsGrounded)
		{
			if(_velocity.Y > 0) {
				Debug.Log("Camera Y position" + _camera.Position.Y + " Velocity Y: " + _velocity.Y);
			}
			//airmove
			_velocity.Y -= 30 * Time.DeltaTime;  //<-- different heights reached
                        //_velocity.Y -= 0.6f;   // <-- Consistent height
			Q3Accelerate(input, 5 * speedMultiplier, 2.0f);
		}
```