### PR TITLE
Avoids not losing velocity when colliding toward a wall

### DIFF
--- a/Source/Game/DemoFps.cs
+++ b/Source/Game/DemoFps.cs
@@ -232,6 +232,22 @@ public class DemoFps : Script, IKinematicCharacter
 		{
 			_velocity.Y = 0.0f;
 		}
+
+		// Handle wall collisions during jumps  
+		if(!_kcc.IsGrounded)  
+		{  
+			// Check if this is a wall collision (normal is roughly horizontal)  
+			float wallThreshold = 0.1f; // Adjust as needed  
+			if(Math.Abs(Vector3.Dot(hit.Normal, _kcc.GravityEulerNormalized)) < wallThreshold)  
+			{  
+				// Remove velocity component toward the wall  
+				Vector3 velocityTowardWall = Vector3.Project(_velocity, -hit.Normal);  
+				if(Vector3.Dot(velocityTowardWall, -hit.Normal) > 0)  
+				{  
+					_velocity -= velocityTowardWall;  
+				}  
+			}  
+		}  
     }
 
     public void KinematicUnstuckEvent(Collider collider, Vector3 penetrationDirection, float penetrationDistance)


### PR DESCRIPTION
When jumping towards a wall, the velocity was maintained so if you slide on the side of the wall before touching the ground you will go at full speed although the wall should have removed that speed.


This can be checked easily jumping on this mark (or near the corner of any wall although I found it more difficult)

<img width="1087" height="582" alt="imagen" src="https://github.com/user-attachments/assets/23d07613-8c8e-48d4-b50d-bed5dd820d4b" />
